### PR TITLE
Fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 // Date: March 30 2017 
 // Memory Allocation
 
-This specific source code written in C++ is compiled in Visual Studios 2015 in windows 10.
+This specific source code written in C++ is compiled in Visual Studios 2015 in Windows 10.
 
 Some assumptions for the source code
 1) We will assume that through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocation & allocation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Some assumptions for the source code
 
 Limitations of memory allocator
 
-1) The memory leak detection is very limited, we will indicate to users if there is a memory leak
+1) Memory leak detection is limited. We will indicate to users if a memory leak occurs
 2) The purposed template is built around vectors as vectors have the ability to deal with an allocation object
    std::vector / template < class T, class Alloc = allocator<T> > class vector; // generic template
    SOURCE: http://www.cplusplus.com/reference/vector/vector/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This specific source code written in C++ is compiled in Visual Studios 2015 in Windows 10.
 
 Some assumptions for the source code
-1) Through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocation & allocation
+1) Through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocations and allocations
 2) Tests will be run one at a time
 
 Limitations of memory allocator

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 // Date: March 30 2017 
 // Memory Allocation
 
-This specific source code written in C++ is complied in Visual Studios 2015 in windows 10.
+This specific source code written in C++ is compiled in Visual Studios 2015 in windows 10.
 
 Some assumptions for the source code
 1) We will assume that through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocation & allocation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This specific source code written in C++ is compiled in Visual Studios 2015 in Windows 10.
 
 Some assumptions for the source code
-1) We will assume that through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocation & allocation
+1) Through the allocator, we can track the number of allocations and decide if there is a memory leak based on the number of deallocation & allocation
 2) Tests will be run one at a time
 
 Limitations of memory allocator


### PR DESCRIPTION
- "complied" -> "compiled"
#2 
- "windows" -> "Windows"
- "We will assume that through the allocator, we can track..." ->"Through the allocator, we can track..."
- "...the number of deallocation & allocation..." -> "... the number of deallocations and allocations..."
- "The memory leak detection is very limited, we will indicate to users if there is a memory leak" -> "Memory leak detection is limited. We will indicate to users if a memory leak occurs."